### PR TITLE
Add resolving dependencies on factory side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes History
 
+1.3.1
+-----
+- Resolving service dependency now happened on factory side in case if service inherit EntityService class
+and don't has own constructor. 
+
 1.3.0
 -----
 - Remove direct dependency from dingo/api

--- a/src/Services/EntityServiceFactory.php
+++ b/src/Services/EntityServiceFactory.php
@@ -83,14 +83,20 @@ class EntityServiceFactory implements IEntityServiceFactory
     protected function buildEntityService(string $modelClass): IEntityService
     {
         try {
-            if (isset($this->registeredServices[$modelClass])) {
-                return $this->container->make($this->registeredServices[$modelClass]);
+            $entityServiceClass = $this->registeredServices[$modelClass] ?? EntityService::class;
+
+            $parameters = [];
+
+            if ($entityServiceClass === EntityService::class ||
+                is_subclass_of($entityServiceClass, EntityService::class)
+            ) {
+                $parameters = [
+                    'className' => $modelClass,
+                    'repository' => $this->repositoryFactory->getRepository($modelClass),
+                ];
             }
 
-            return $this->container->make(EntityService::class, [
-                'className' => $modelClass,
-                'repository' => $this->repositoryFactory->getRepository($modelClass),
-            ]);
+            return $this->container->make($entityServiceClass, $parameters);
         } catch (RepositoryException $exception) {
             throw new EntityServiceException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/tests/EntityServiceFactoryTest.php
+++ b/tests/EntityServiceFactoryTest.php
@@ -79,8 +79,8 @@ class EntityServiceFactoryTest extends TestCase
             $this->repositoryFactory->shouldReceive('getRepository')
                 ->withArgs([$model])
                 ->andReturn(Mockery::mock(IRepository::class));
-            $this->container->shouldReceive('make')->withArgs([$serviceClass])->andReturn($expectedService);
-            $actualService= $entityServiceFactory->build($model);
+            $this->container->shouldReceive('make')->andReturn($expectedService);
+            $actualService = $entityServiceFactory->build($model);
             $this->assertSame($expectedService, $actualService);
         }
     }


### PR DESCRIPTION
## Changes:
- Resolving service dependency now happened on factory side in case if service inherit EntityService class
and don't has own constructor.

Fixes #2 